### PR TITLE
Adding Missing Generics for Engine to Getting Started Tutorial

### DIFF
--- a/src/rg3d/beginning/framework.md
+++ b/src/rg3d/beginning/framework.md
@@ -13,11 +13,12 @@ use rg3d::{
     engine::Engine,
     engine::framework::prelude::*,
 };
+use rg3d::gui::node::StubNode;
 
 struct Game { }
 
 impl GameState for Game {
-    fn init(_engine: &mut Engine) -> Self where Self: Sized {
+    fn init(_engine: &mut Engine<(), StubNode>) -> Self where Self: Sized {
         Self { }
     }
 }

--- a/src/rg3d/beginning/framework.md
+++ b/src/rg3d/beginning/framework.md
@@ -12,8 +12,8 @@ The simplest app could be created with this code:
 use rg3d::{
     engine::Engine,
     engine::framework::prelude::*,
+    gui::node::StubNode,
 };
-use rg3d::gui::node::StubNode;
 
 struct Game { }
 
@@ -60,13 +60,14 @@ As you can see it is very concise and simple, every method serves a particular p
 #   core::color::{Color, Hsv},
 #   engine::{framework::prelude::*, Engine},
 #   event_loop::ControlFlow,
+#   gui::node::StubNode,
 # };
 struct Game {
     hue: f32,
 }
 
 impl GameState for Game {
-    fn init(_engine: &mut Engine) -> Self
+    fn init(_engine: &mut Engine<(), StubNode>) -> Self
     where
         Self: Sized,
     {


### PR DESCRIPTION
Hey there, I'm running through the book right now and spotted a small issue. The example in the getting started tutorial doesn't compile because its missing generics for Engine. Based on what I saw in the API docs this seems to be the right way to fix it.