### PR TITLE
Add `deps` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 !.github
 book
 .idea
+deps


### PR DESCRIPTION
This allows creating a local dependencies directory that can be used when testing the snippets, instead of holding the whole project.

Regardless of holding the whole project or only the dependencies, some directory needs to be ignored, otherwise it interferes with the book development/testing workflow :)