### PR TITLE
Fix typo in link to chapter about creating scene

### DIFF
--- a/src/fyrox/scene/scene.md
+++ b/src/fyrox/scene/scene.md
@@ -18,7 +18,7 @@ manually.
 
 ### Using Fyroxed
 
-There is a [separate chapter](../../fyroxed/introduction.md) in the book that should help you to create a scene.
+There is a [separate chapter](../../fyrox/introduction.md) in the book that should help you to create a scene.
 
 After a scene is created, you can load it as any other 3D model using the resource manager:
 


### PR DESCRIPTION
When clicking on the link "separate Chapter" in *2.2. Scene*, we recieve a 404 error.
This is because there is a typo in the link, it is: `/fyroxed/introduction.md` when it should be `/fyrox/introduction.md` (note the *ed*).

