### PR TITLE
Allow fyrox.rs to have this as a subpage.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+# Jekyll Config
+url: https://fyrox.rs/
+baseurl: /book


### PR DESCRIPTION
This will set the Fyrox book to be created as a subpage of the fyrox.rs site.

My understanding is though, it is necessary to transfer this repository to the FyroxEngine GH organisation. 

Because no ``_nojekyll`` (iirc that's the filename), it will automatically be created as a subpage when transferred