### PR TITLE
Fix some broken links.

### DIFF
--- a/src/editor/index.md
+++ b/src/editor/index.md
@@ -1,8 +1,8 @@
 # Editor
 
-This section of the book covers various aspects of the editor. Keep in mind, that this section covers aspects of the 
-editor, that does not have direct relations with engine entities. For example, this section covers 
-[Editor Settings](settings.md), but does not cover [Animation Editor](../animation/editor.md). This is because, it 
+This section of the book covers various aspects of the editor. Keep in mind, that this section covers aspects of the
+editor, that does not have direct relations with engine entities. For example, this section covers
+[Editor Settings](settings.md), but does not cover [Animation Editor](../animation/anim_editor.md). This is because, it
 is better to show how to use a thing from both sides at once (code and editor), than split it to separate sections.
 
 In this section, you'll know how to use editor-specific parts of the engine, how to use special tools it provides.

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -2,25 +2,25 @@
 
 Practical reference and user guides for [Fyrox Game Engine](https://github.com/FyroxEngine/Fyrox) and its editor [FyroxEd](https://github.com/FyroxEngine/Fyrox/tree/master/editor).
 
-> ⚠️ Tip: If you want to start using the engine as fast as possible - read this [chapter](fyrox/beginning/scripting.md).
+> ⚠️ Tip: If you want to start using the engine as fast as possible - read this [chapter](src/beginning/scripting.md).
 
 **Warning:** The book is in early development stage, you can help to improve it by making a contribution in its
 [repository](https://github.com/fyrox-book/fyrox-book.github.io). Don't be shy, every tip is helpful!
 
 ## Engine Version
 
-Fyrox Team is trying to keep the book up-to-date with the latest version from `master` branch. If something does not 
-compile with the latest release from crates.io, then you need to 
+Fyrox Team is trying to keep the book up-to-date with the latest version from `master` branch. If something does not
+compile with the latest release from crates.io, then you need to
 [use the latest engine from GitHub repo](./beginning/scripting.md#using-latest-engine-version).
 
 ## How to read the book
 
 Almost every chapter in this book can be read in any order, but we recommend reading Chapters 1, 2, 3 (they're quite small)
-and then going through [Platformer Tutorial (2D)](fyrox/tutorials/platformer/part1.md) while learning more about specific 
+and then going through [Platformer Tutorial (2D)](src/tutorials/platformer/part1.md) while learning more about specific
 areas that interest you from the other chapters.
 
-There is also a [First-Person Shooter Tutorial (3D)](fyrox/tutorials/fps/intro.md), but it is based on framework which
-considered obsolete, yet it is still very helpful. 
+There is also a [First-Person Shooter Tutorial (3D)](src/tutorials/fps/intro.md), but it is based on framework which
+considered obsolete, yet it is still very helpful.
 
 ## API Documentation
 
@@ -30,8 +30,8 @@ The book is primarily focused on game development with Fyrox, not on its API. Yo
 ## Required knowledge
 
 We're expecting that you know basics of Rust programming language, its package manager Cargo. It is also necessary
-to know the _basics_ of the game development, linear algebra, principles of software development and patterns, 
-otherwise the book will probably be very hard for you. 
+to know the _basics_ of the game development, linear algebra, principles of software development and patterns,
+otherwise the book will probably be very hard for you.
 
 ## Support the development
 

--- a/src/performance/index.md
+++ b/src/performance/index.md
@@ -1,7 +1,7 @@
 # Performance
 
 This section of the book covers very specific cases of extreme performance, that is suitable for some exceptional cases.
-For the vast majority of cases, standard engine approaches are perfectly fine. 
+For the vast majority of cases, standard engine approaches are perfectly fine.
 
 ## ECS
 
@@ -59,4 +59,4 @@ generational arenas (_pool_ in Fyrox's terminology) and handles. Instead of stor
 you put all your objects in a pool, and it gives you handles which can later be used to borrow a reference to
 that object. This approach allows you to build any data structures that may hold "references" to other objects.
 The references replaced with handles, which can be treated (very roughly) as just an index. See
-[separate chapter](./beginning/data_management.md) in the book for more info.
+[separate chapter](src/beginning/data_management.md) in the book for more info.

--- a/src/scene/scene.md
+++ b/src/scene/scene.md
@@ -1,11 +1,11 @@
-# Scene 
+# Scene
 
 Scene is a container for game entities. Currently, scenes in the engine manage following entities:
 
 1) Graph
 2) Animations
 3) Physics (rigid bodies, colliders, joints)
-4) Sound 
+4) Sound
 
 Scene allows you to create isolated "world" which won't interact with other scenes, it is very useful for many
 more or less complex games.
@@ -18,7 +18,7 @@ manually by instantiating respective prefabs at runtime.
 
 ### Using FyroxEd
 
-There is a [separate chapter](../../beginning/editor_overview.md) in the book that should help you to create a 
+There is a [separate chapter](../beginning/editor_overview.md) in the book that should help you to create a
 scene. After a scene is created, you can load it as any other 3D model (or prefab) using the resource manager:
 
 ```rust,no_run
@@ -49,7 +49,7 @@ fn load_scene(resource_manager: ResourceManager) -> Scene {
 ```
 
 Please note that here we're creating an empty scene and only then instantiating another scene into it. Why is this
-needed? Child scene is considered as [prefab](./prefab.md), and it is "instantiated" in the parent scene. Considering 
+needed? Child scene is considered as [prefab](./prefab.md), and it is "instantiated" in the parent scene. Considering
 it as prefab allows you modifying your scene separately and serialization/deserialization will be able to correctly
 apply any changes in the scene.
 
@@ -85,7 +85,7 @@ You can borrow a scene at any time using its handle and do some changes:
 #     plugin::{Plugin, PluginContext},
 #     scene::Scene,
 # };
-# 
+#
 struct Game {
     scene: Handle<Scene>,
 }
@@ -102,27 +102,27 @@ impl Plugin for Game {
 }
 ```
 
-## Building scene asynchronously 
+## Building scene asynchronously
 
-You can create your scene in separate thread and then pass it to main thread to insert it in the engine. Why this 
-is needed? Remember the last time you've played a relatively large game, you've probably noticed that it have 
-loading screens and loading screen has some fancy interactive stuff with progress bar. Loading screen is fully 
+You can create your scene in separate thread and then pass it to main thread to insert it in the engine. Why this
+is needed? Remember the last time you've played a relatively large game, you've probably noticed that it have
+loading screens and loading screen has some fancy interactive stuff with progress bar. Loading screen is fully
 responsive while the game doing hard job loading the world for you. Got it already? Asynchronous scene loading is
-needed to create/load large scenes with tons of resources without blocking main thread, thus leaving the game 
+needed to create/load large scenes with tons of resources without blocking main thread, thus leaving the game
 fully responsive.
 
 ## Managing multiple scenes
 
-Usually you should have only one scene active (unless you're making something very special), you should use 
+Usually you should have only one scene active (unless you're making something very special), you should use
 `.enabled` flag of a scene to turn it off or on. Deactivated scenes won't be rendered, the physics won't be
 updated, the sound will stop, and so on. In other words the scene will be frozen. This is useful for situations
 when you often need to switch between scenes, leaving other scene in frozen state. One of the examples where this
-can be useful is menus. In most games when you're entering the menu, game world is paused. 
+can be useful is menus. In most games when you're entering the menu, game world is paused.
 
 ## Ambient lighting
 
-Every scene has default ambient lighting, it is defined by a single RGB color. By default, every scene has 
-some pre-defined ambient lighting, it is bright enough, so you can see your objects. In some cases you may 
+Every scene has default ambient lighting, it is defined by a single RGB color. By default, every scene has
+some pre-defined ambient lighting, it is bright enough, so you can see your objects. In some cases you may
 need to adjust it or even make it black (for horror games for instance), this can be achieved by a single
 line of code:
 
@@ -131,8 +131,8 @@ line of code:
 # use fyrox::scene::Scene;
 # use fyrox::core::color::Color;
 # let mut scene = Scene::default();
-# 
-scene.rendering_options.ambient_lighting_color = Color::opaque(30, 30, 30); 
+#
+scene.rendering_options.ambient_lighting_color = Color::opaque(30, 30, 30);
 ```
 
 Please keep in mind that ambient lighting does not mean global illumination, it is a different lighting technique

--- a/src/ui/widgets.md
+++ b/src/ui/widgets.md
@@ -2,7 +2,6 @@
 
 The subsections of this chapter explains how to use every widget built into Fyrox. The widgets in the table of contents to the left are ordered in alphebetical order. However, below we will order them by primary function to help introduce them to new users.
 
-
 ## Containers
 
 The Container widgets primary purpose is to contain other widgets. They are mostly used as a tool to layout the UI in visually different ways.
@@ -38,7 +37,7 @@ The Visual widgets primary purpose is to provide the user feedback generally wit
 
 Control widgets primary purpose is to provide users with intractable UI elements to control some aspect of the program.
 
-* [Button](./creating_button.md): The Button provides a press-able control that can contain other UI elements, for example a Text or Image Widget.
+* [Button](./button.md): The Button provides a press-able control that can contain other UI elements, for example a Text or Image Widget.
 * [Check Box](./checkbox/check_box.md): The Check Box is a toggle-able control that can contain other UI elements, for example a Text or Image Widget.
 * [Text Box](./text_box.md): The Text Box is a control that allows the editing of text.
 * [Scroll Bar](./scroll_bar.md): The Scroll Bar provides a scroll bar like control that can be used on it's own as a data input or with certain other widgets to provide content scrolling capabilities.


### PR DESCRIPTION
A number of links to other markdown documents used nonexistent paths.
For example, if you visit https://fyrox-book.github.io/introduction.html
and click the "chapter" link in "read this chapter", it takes you to
https://fyrox-book.github.io/fyrox/beginning/scripting.html, which does not exist.
