### PR TITLE
Trying again to fix formulas

### DIFF
--- a/src/scene/terrain_node.md
+++ b/src/scene/terrain_node.md
@@ -71,7 +71,7 @@ Masks are always clamped to be between 0 and 1, regardless of what brush mode is
 and 1 represents the layer being fully opaque.
 - *Transform:* This is a 2x2 matrix that is applied to the brush's shape, allowing linear transformations such as rotating
 a rectangular brush, or skewing, or stretching.
-For most purposes the identity matrix of \\(begin{bmatrix}1&0\\0&1\end{bmatrix}\\) works well, since that is the default that applies no modification to the brush's shape.
+For most purposes the identity matrix of \\(begin{bmatrix}1&0\\\\0&1\end{bmatrix}\\) works well, since that is the default that applies no modification to the brush's shape.
 If the matrix is not invertable, then it will be ignored.
 - *Hardness:* The effect of a brush does not need to be applied equally across its entire area. The *hardness*
 of a brush controls how much of a brush gets its full effect.
@@ -81,7 +81,7 @@ When hardness is 1 or greater, the entire brush gets the full effect.
 If the value is less than 0, then even the center of the brush does not receive the full effect.
 - *Alpha:* The \\(\alpha\\) value linearlly interpolates between the current value of the terrain and the value that would be
 produced by the full effect of the brush.
-If $v_0$ is the current value of a point on the terrain and and $v_1$ is the full effect of the brush, then the actual
+If \\(v_0\\) is the current value of a point on the terrain and and \\(v_1\\) is the full effect of the brush, then the actual
 effect that the brush will apply will be \\((1 - \alpha) * v_0 + \alpha * v_1\\).
 There is no requirement that \\(\alpha\\) must be between 0 and 1. Values less than 0 will invert the effect of the brush,
 while values greater than 1 will exaggerate the effect of the brush.


### PR DESCRIPTION
The mistake I made was in overlooking two tiny formulas and in failing to realize that the rules require that the `\\` which would usually separate the rows of a matrix need to be replaced by `\\\\`. Hopefully this time there should be no remaining problems.