### PR TITLE
enable the Edit button on a book pages

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -9,8 +9,14 @@ title = "Fyrox Book"
 mathjax-support = true
 default-theme = "navy"
 preferred-dark-theme = "navy"
-git-repository-url = "https://github.com/fyrox-book/fyrox-book.github.io"
 git-repository-icon = "fa-github"
+site-url = "/fyrox-book.github.io/"
+git-repository-url = "https://github.com/fyrox-book/fyrox-book.github.io/tree/main"
+edit-url-template = "https://github.com/fyrox-book/fyrox-book.github.io/edit/main/{path}"
+
+[output.html.playground]
+editable = true
+line-numbers = true
 
 [output.html.fold]
 enable = true


### PR DESCRIPTION
In the reference [mdBook](https://rust-lang.github.io/mdBook/guide/creating.html) there is an "edit" button at the top-right corner of a screen:
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/92680719-5762-4152-965c-8db2a04db1d7">
It allows editing a book's text in-place and then create a Pull Request with made changes. This way is more simple then cloning a book repo to local pc, editing it through VS Code and testing with `mdbook serve --open`.

I made this changes by comparing the reference [book.toml](https://github.com/rust-lang/mdBook/blob/master/guide/book.toml) and the fyrox [book.toml](https://github.com/Vlad2001MFS/fyrox-book.github.io/blob/main/book.toml) and then just check an existence of this button in my fork by running the `mdbook serve --open` locally on my pc. Also, after pressing the "edit" button, I'm successfully going to the edit page in my fork of the fyrox-book.github.io.
![image](https://github.com/user-attachments/assets/4ccc0bfe-18ee-483d-9cce-9fa1c60bb396)
