### PR TITLE
Correcting the path to the flood_fill.gif file

### DIFF
--- a/src/scene/tilemap.md
+++ b/src/scene/tilemap.md
@@ -239,7 +239,7 @@ Activate it using the button with paint bucket icon.
 Unlike the other tools, the flood fill tool is not implemented for use in the Tile Set Editor,
 so in the Tile Set Editor the flood tool will just act like the brush tool.
 
-![flood fill](tile_map_tools/flood_fill.gif)
+![flood fill](flood_fill.gif)
 
 ### Pick Tool
 


### PR DESCRIPTION
I didn't notice right away that I copied the wrong path. I apologize. Now the image is drawn correctly.